### PR TITLE
wifi: fix SPI speed

### DIFF
--- a/linux/testoverlay.dts
+++ b/linux/testoverlay.dts
@@ -20,7 +20,7 @@
 			nrf7002_ek: nrf7002@0 {
 				compatible = "nordic,nrf7002";
 				reg = <0x0>;
-				spi-max-frequency = <32000000>;
+				spi-max-frequency = <31200000>;
 				spi-bits-per-word = <8>;
 				status = "okay";
 				bucken-gpio = <&gpio 16 0>;


### PR DESCRIPTION
Change the SPI clock to 31.2MHz to match actual
SPI speed of Raspbery Pi.

Reference:
https://elinux.org/RPi_SPI